### PR TITLE
Fixing a bug with comment parsing

### DIFF
--- a/vdfparser.php
+++ b/vdfparser.php
@@ -1,11 +1,9 @@
 <?php
 
 /*
-
 	* VDF (Valve Data Format) file parser
 	* author: devinwl
-	* version: 1.04
-
+	* version: 1.05
 */
 
 define("QUOTE", "\"");
@@ -21,10 +19,10 @@ define('C_COMMENT', '/');
 function VDFParse($filename) {
 	$parsed = array();
 	$ptr = &$parsed;
-	$path = '';				// The current level represented as a string
-	$p = 0;					// How many quotes have been seen
+	$path = '';			// The current level represented as a string
+	$p = 0;				// How many quotes have been seen
 	$string = "";			// The string of consumed characters
-	$key = "";				// The discovered key
+	$key = "";			// The discovered key
 	$value = "";			// The discovered corresponding value
 	$reading = false;		// Currently consuming characters
 	$lastCharSeen = "";		// Tracks the last character seen
@@ -136,7 +134,9 @@ function VDFParse($filename) {
 					break;
 
 					case C_COMMENT:
-						$comment_chars_seen++;
+						// Only look for comments if we're not currently reading a key or value
+						if(!$reading)
+							$comment_chars_seen++;
 
 					break;
 


### PR DESCRIPTION
If a comment is encountered inside a key or value, the parser would treat it as a real comment, instead of being a part of the key/value.  Now comments are only handled if they are outside of the key/value structure.

Also fixes an issue with URLs inside key/values too (e.g. http:// would trigger comment detection).
